### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,94 @@ source /workspace/.venv/bin/activate
 | Docs dev server | `cd website && npm start` |
 | Docs build | `cd website && npm run build` |
 
-### Docker and Molecule limitations in Cloud Agent VMs
+### Docker-in-Docker workarounds for Molecule tests
 
-- Docker containers that set **memory limits** (`-m` / `memory:`) will fail with a cgroup v2 "domain threaded" error. This is a known limitation of the nested container environment (Docker inside a container inside Firecracker VM).
-- Molecule tests use the Docker driver and may encounter this cgroup limitation when the role under test sets `memory:` on its containers.
-- Docker must be started manually: `sudo dockerd &>/tmp/dockerd.log &` followed by `sudo chmod 666 /var/run/docker.sock`. The `fuse-overlayfs` storage driver and `iptables-legacy` are required (already configured in `/etc/docker/daemon.json` and via `update-alternatives`).
+The Cloud Agent VM is itself a container inside a Firecracker VM. Running Docker
+inside it (needed for Molecule's Docker driver) requires several workarounds.
+
+#### 1. Install Docker with nested-container patches
+
+```bash
+# Install Docker CE
+sudo install -m 0755 -d /etc/apt/keyrings
+curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y \
+  docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+  docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+  containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+#### 2. Use fuse-overlayfs storage driver
+
+The kernel does not support all overlay2 features inside the nested environment.
+`fuse-overlayfs` is required as the Docker storage driver.
+
+```bash
+sudo apt-get install -y fuse-overlayfs
+sudo mkdir -p /etc/docker
+printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' \
+  | sudo tee /etc/docker/daemon.json
+```
+
+#### 3. Switch to iptables-legacy
+
+The kernel does not support all nftables features. Docker networking requires
+the legacy iptables backend.
+
+```bash
+sudo apt-get install -y iptables
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+```
+
+#### 4. Start the Docker daemon manually
+
+There is no systemd running in the VM, so Docker must be started as a
+background process.
+
+```bash
+sudo dockerd &>/tmp/dockerd.log &
+sleep 3
+sudo chmod 666 /var/run/docker.sock   # allow non-root access
+```
+
+Verify with `docker run --rm hello-world`.
+
+#### 5. cgroup v2 "domain threaded" limitation
+
+The VM's root cgroup is in **domain threaded** mode. Any Docker container that
+sets a **memory limit** (`-m` / `--memory` / the `memory:` key in
+`community.docker.docker_container`) will fail at start with:
+
+```
+unable to apply cgroup configuration: cannot enter cgroupv2
+"/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode
+```
+
+**Impact on Molecule tests:** Molecule tests that converge a role deploy
+containers on the *host* Docker daemon (the socket is bind-mounted into the
+Molecule test container). If the role's task sets `memory:` on a container, the
+converge step will fail. Roles that do **not** set memory limits pass without
+issues — all 22 core roles with Molecule tests pass today because their
+converge playbooks do not trigger this path.
+
+**Workaround when running a role directly (not via Molecule):** Override the
+`memory` variable to `"0"` (disables the limit) and remove any stale
+containers from a previous failed attempt before re-running:
+
+```bash
+docker rm -f <container_name>
+ANSIBLE_ROLES_PATH=/workspace/roles ansible-playbook -i localhost, -c local \
+  -e "<role>_memory=0" playbook.yml
+```
+
+There is no workaround that preserves the memory limit inside this VM.
 
 ### Pre-existing lint issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Ansible-NAS is an Ansible project that deploys ~280 Docker-based applications to a home server. The main playbook is `nas.yml`; roles live under `roles/`. A Docusaurus documentation site lives in `website/`.
+
+### Python virtual environment
+
+A Python 3.13 venv is located at `/workspace/.venv`. Always activate it before running any commands:
+
+```
+source /workspace/.venv/bin/activate
+```
+
+### Key commands
+
+| Task | Command |
+|---|---|
+| Syntax check | `ansible-playbook -i inventory nas.yml --syntax-check` |
+| Ansible lint | `ansible-lint nas.yml` |
+| YAML lint | `yamllint .` |
+| Run a Molecule test | `cd roles/<role> && molecule -c ../../tests/molecule/base.yml test` |
+| Docs dev server | `cd website && npm start` |
+| Docs build | `cd website && npm run build` |
+
+### Docker and Molecule limitations in Cloud Agent VMs
+
+- Docker containers that set **memory limits** (`-m` / `memory:`) will fail with a cgroup v2 "domain threaded" error. This is a known limitation of the nested container environment (Docker inside a container inside Firecracker VM).
+- Molecule tests use the Docker driver and may encounter this cgroup limitation when the role under test sets `memory:` on its containers.
+- Docker must be started manually: `sudo dockerd &>/tmp/dockerd.log &` followed by `sudo chmod 666 /var/run/docker.sock`. The `fuse-overlayfs` storage driver and `iptables-legacy` are required (already configured in `/etc/docker/daemon.json` and via `update-alternatives`).
+
+### Pre-existing lint issues
+
+The repository has pre-existing `yamllint` and `ansible-lint` findings (trailing spaces, missing newlines at end of file, var naming, etc.). These are not regressions from agent changes — they exist in the upstream codebase.

--- a/roles/adguard/molecule/default/molecule.yml
+++ b/roles/adguard/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        adguard_enabled: true

--- a/roles/adguard/molecule/default/side_effect.yml
+++ b/roles/adguard/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        adguard_enabled: false

--- a/roles/adguard/molecule/default/verify.yml
+++ b/roles/adguard/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ adguard_container_name }}"
+      register: result
+
+    - name: Check Adguard is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/adguard/molecule/default/verify_stopped.yml
+++ b/roles/adguard/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Adguard
+      community.docker.docker_container:
+        name: "{{ adguard_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check Adguard is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/basen/molecule/default/molecule.yml
+++ b/roles/basen/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        basen_enabled: true

--- a/roles/basen/molecule/default/side_effect.yml
+++ b/roles/basen/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        basen_enabled: false

--- a/roles/basen/molecule/default/verify.yml
+++ b/roles/basen/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ basen_container_name }}"
+      register: result
+
+    - name: Check Basen is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/basen/molecule/default/verify_stopped.yml
+++ b/roles/basen/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Basen
+      community.docker.docker_container:
+        name: "{{ basen_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check Basen is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/beszel/molecule/default/molecule.yml
+++ b/roles/beszel/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        beszel_enabled: true

--- a/roles/beszel/molecule/default/side_effect.yml
+++ b/roles/beszel/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        beszel_enabled: false

--- a/roles/beszel/molecule/default/verify.yml
+++ b/roles/beszel/molecule/default/verify.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get Beszel Hub container state
+      community.docker.docker_container_info:
+        name: "{{ beszel_container_name }}"
+      register: result_hub
+
+    - name: Get Beszel Agent container state
+      community.docker.docker_container_info:
+        name: "{{ beszel_agent_container_name }}"
+      register: result_agent
+
+    - name: Check Beszel containers are running
+      ansible.builtin.assert:
+        that:
+          - result_hub.container['State']['Status'] == "running"
+          - result_hub.container['State']['Restarting'] == false
+          - result_agent.container['State']['Status'] == "running"
+          - result_agent.container['State']['Restarting'] == false

--- a/roles/beszel/molecule/default/verify_stopped.yml
+++ b/roles/beszel/molecule/default/verify_stopped.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Beszel Hub
+      community.docker.docker_container:
+        name: "{{ beszel_container_name }}"
+        state: absent
+      register: result_hub
+
+    - name: Try and stop and remove Beszel Agent
+      community.docker.docker_container:
+        name: "{{ beszel_agent_container_name }}"
+        state: absent
+      register: result_agent
+
+    - name: Check Beszel containers are stopped
+      ansible.builtin.assert:
+        that:
+          - not result_hub.changed
+          - not result_agent.changed

--- a/roles/dawarich/molecule/default/molecule.yml
+++ b/roles/dawarich/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        dawarich_enabled: true

--- a/roles/dawarich/molecule/default/side_effect.yml
+++ b/roles/dawarich/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        dawarich_enabled: false

--- a/roles/dawarich/molecule/default/verify.yml
+++ b/roles/dawarich/molecule/default/verify.yml
@@ -1,0 +1,40 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get Dawarich Redis container state
+      community.docker.docker_container_info:
+        name: "{{ dawarich_redis_container_name }}"
+      register: result_redis
+
+    - name: Get Dawarich Postgres container state
+      community.docker.docker_container_info:
+        name: "{{ dawarich_pg_container_name }}"
+      register: result_pg
+
+    - name: Get Dawarich App container state
+      community.docker.docker_container_info:
+        name: "{{ dawarich_app_container_name }}"
+      register: result_app
+
+    - name: Get Dawarich Sidekiq container state
+      community.docker.docker_container_info:
+        name: "{{ dawarich_sidekiq_container_name }}"
+      register: result_sidekiq
+
+    - name: Check Dawarich containers are running
+      ansible.builtin.assert:
+        that:
+          - result_redis.container['State']['Status'] == "running"
+          - result_redis.container['State']['Restarting'] == false
+          - result_pg.container['State']['Status'] == "running"
+          - result_pg.container['State']['Restarting'] == false
+          - result_app.container['State']['Status'] == "running"
+          - result_app.container['State']['Restarting'] == false
+          - result_sidekiq.container['State']['Status'] == "running"
+          - result_sidekiq.container['State']['Restarting'] == false

--- a/roles/dawarich/molecule/default/verify_stopped.yml
+++ b/roles/dawarich/molecule/default/verify_stopped.yml
@@ -1,0 +1,40 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Dawarich Redis
+      community.docker.docker_container:
+        name: "{{ dawarich_redis_container_name }}"
+        state: absent
+      register: result_redis
+
+    - name: Try and stop and remove Dawarich Postgres
+      community.docker.docker_container:
+        name: "{{ dawarich_pg_container_name }}"
+        state: absent
+      register: result_pg
+
+    - name: Try and stop and remove Dawarich App
+      community.docker.docker_container:
+        name: "{{ dawarich_app_container_name }}"
+        state: absent
+      register: result_app
+
+    - name: Try and stop and remove Dawarich Sidekiq
+      community.docker.docker_container:
+        name: "{{ dawarich_sidekiq_container_name }}"
+        state: absent
+      register: result_sidekiq
+
+    - name: Check Dawarich containers are stopped
+      ansible.builtin.assert:
+        that:
+          - not result_redis.changed
+          - not result_pg.changed
+          - not result_app.changed
+          - not result_sidekiq.changed

--- a/roles/ftp_server/molecule/default/molecule.yml
+++ b/roles/ftp_server/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        ftp_server_enabled: true

--- a/roles/ftp_server/molecule/default/side_effect.yml
+++ b/roles/ftp_server/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        ftp_server_enabled: false

--- a/roles/ftp_server/molecule/default/verify.yml
+++ b/roles/ftp_server/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ ftp_server_container_name }}"
+      register: result
+
+    - name: Check FTP Server is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/ftp_server/molecule/default/verify_stopped.yml
+++ b/roles/ftp_server/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove FTP Server
+      community.docker.docker_container:
+        name: "{{ ftp_server_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check FTP Server is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/handbrake/molecule/default/molecule.yml
+++ b/roles/handbrake/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        handbrake_enabled: true

--- a/roles/handbrake/molecule/default/side_effect.yml
+++ b/roles/handbrake/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        handbrake_enabled: false

--- a/roles/handbrake/molecule/default/verify.yml
+++ b/roles/handbrake/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ handbrake_container_name }}"
+      register: result
+
+    - name: Check Handbrake is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/handbrake/molecule/default/verify_stopped.yml
+++ b/roles/handbrake/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Handbrake
+      community.docker.docker_container:
+        name: "{{ handbrake_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check Handbrake is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/netalertx/molecule/default/molecule.yml
+++ b/roles/netalertx/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        netalertx_enabled: true

--- a/roles/netalertx/molecule/default/side_effect.yml
+++ b/roles/netalertx/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        netalertx_enabled: false

--- a/roles/netalertx/molecule/default/verify.yml
+++ b/roles/netalertx/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ netalertx_container_name }}"
+      register: result
+
+    - name: Check NetAlertX is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/netalertx/molecule/default/verify_stopped.yml
+++ b/roles/netalertx/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove NetAlertX
+      community.docker.docker_container:
+        name: "{{ netalertx_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check NetAlertX is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/ollama/molecule/default/molecule.yml
+++ b/roles/ollama/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        ollama_enabled: true

--- a/roles/ollama/molecule/default/side_effect.yml
+++ b/roles/ollama/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        ollama_enabled: false

--- a/roles/ollama/molecule/default/verify.yml
+++ b/roles/ollama/molecule/default/verify.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get Ollama container state
+      community.docker.docker_container_info:
+        name: "{{ ollama_container_name }}"
+      register: result_ollama
+
+    - name: Get Ollama WebUI container state
+      community.docker.docker_container_info:
+        name: "{{ ollama_webui_container_name }}"
+      register: result_webui
+
+    - name: Check Ollama containers are running
+      ansible.builtin.assert:
+        that:
+          - result_ollama.container['State']['Status'] == "running"
+          - result_ollama.container['State']['Restarting'] == false
+          - result_webui.container['State']['Status'] == "running"
+          - result_webui.container['State']['Restarting'] == false

--- a/roles/ollama/molecule/default/verify_stopped.yml
+++ b/roles/ollama/molecule/default/verify_stopped.yml
@@ -1,0 +1,26 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Ollama
+      community.docker.docker_container:
+        name: "{{ ollama_container_name }}"
+        state: absent
+      register: result_ollama
+
+    - name: Try and stop and remove Ollama WebUI
+      community.docker.docker_container:
+        name: "{{ ollama_webui_container_name }}"
+        state: absent
+      register: result_webui
+
+    - name: Check Ollama containers are stopped
+      ansible.builtin.assert:
+        that:
+          - not result_ollama.changed
+          - not result_webui.changed

--- a/roles/reitti/molecule/default/molecule.yml
+++ b/roles/reitti/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        reitti_enabled: true

--- a/roles/reitti/molecule/default/side_effect.yml
+++ b/roles/reitti/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        reitti_enabled: false

--- a/roles/reitti/molecule/default/verify.yml
+++ b/roles/reitti/molecule/default/verify.yml
@@ -1,0 +1,54 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get Reitti PostGIS container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_postgis_container_name }}"
+      register: result_postgis
+
+    - name: Get Reitti Redis container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_redis_container_name }}"
+      register: result_redis
+
+    - name: Get Reitti RabbitMQ container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_rabbitmq_container_name }}"
+      register: result_rabbitmq
+
+    - name: Get Reitti Photon container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_photon_container_name }}"
+      register: result_photon
+
+    - name: Get Reitti Tile Cache container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_tile_cache_container_name }}"
+      register: result_tile_cache
+
+    - name: Get Reitti container state
+      community.docker.docker_container_info:
+        name: "{{ reitti_container_name }}"
+      register: result_reitti
+
+    - name: Check Reitti containers are running
+      ansible.builtin.assert:
+        that:
+          - result_postgis.container['State']['Status'] == "running"
+          - result_postgis.container['State']['Restarting'] == false
+          - result_redis.container['State']['Status'] == "running"
+          - result_redis.container['State']['Restarting'] == false
+          - result_rabbitmq.container['State']['Status'] == "running"
+          - result_rabbitmq.container['State']['Restarting'] == false
+          - result_photon.container['State']['Status'] == "running"
+          - result_photon.container['State']['Restarting'] == false
+          - result_tile_cache.container['State']['Status'] == "running"
+          - result_tile_cache.container['State']['Restarting'] == false
+          - result_reitti.container['State']['Status'] == "running"
+          - result_reitti.container['State']['Restarting'] == false

--- a/roles/reitti/molecule/default/verify_stopped.yml
+++ b/roles/reitti/molecule/default/verify_stopped.yml
@@ -1,0 +1,54 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Reitti
+      community.docker.docker_container:
+        name: "{{ reitti_container_name }}"
+        state: absent
+      register: result_reitti
+
+    - name: Try and stop and remove Reitti Tile Cache
+      community.docker.docker_container:
+        name: "{{ reitti_tile_cache_container_name }}"
+        state: absent
+      register: result_tile_cache
+
+    - name: Try and stop and remove Reitti Photon
+      community.docker.docker_container:
+        name: "{{ reitti_photon_container_name }}"
+        state: absent
+      register: result_photon
+
+    - name: Try and stop and remove Reitti RabbitMQ
+      community.docker.docker_container:
+        name: "{{ reitti_rabbitmq_container_name }}"
+        state: absent
+      register: result_rabbitmq
+
+    - name: Try and stop and remove Reitti Redis
+      community.docker.docker_container:
+        name: "{{ reitti_redis_container_name }}"
+        state: absent
+      register: result_redis
+
+    - name: Try and stop and remove Reitti PostGIS
+      community.docker.docker_container:
+        name: "{{ reitti_postgis_container_name }}"
+        state: absent
+      register: result_postgis
+
+    - name: Check Reitti containers are stopped
+      ansible.builtin.assert:
+        that:
+          - not result_reitti.changed
+          - not result_tile_cache.changed
+          - not result_photon.changed
+          - not result_rabbitmq.changed
+          - not result_redis.changed
+          - not result_postgis.changed

--- a/roles/scrutiny/molecule/default/molecule.yml
+++ b/roles/scrutiny/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scrutiny_enabled: true

--- a/roles/scrutiny/molecule/default/side_effect.yml
+++ b/roles/scrutiny/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        scrutiny_enabled: false

--- a/roles/scrutiny/molecule/default/verify.yml
+++ b/roles/scrutiny/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ scrutiny_container_name }}"
+      register: result
+
+    - name: Check Scrutiny is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/scrutiny/molecule/default/verify_stopped.yml
+++ b/roles/scrutiny/molecule/default/verify_stopped.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include vars
+      ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Scrutiny
+      community.docker.docker_container:
+        name: "{{ scrutiny_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check Scrutiny is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What this PR does / why we need it**:

1. Adds `AGENTS.md` with Cursor Cloud specific development environment instructions, including detailed Docker-in-Docker workarounds for Molecule tests.

2. Adds Molecule test scenarios for all 10 core roles that were missing them:

   **Single-container roles:** `adguard`, `basen`, `ftp_server`, `handbrake`, `netalertx`, `scrutiny`

   **Multi-container roles:**
   - `beszel` (hub + agent, 2 containers)
   - `dawarich` (redis + postgres + app + sidekiq, 4 containers)
   - `ollama` (ollama + webui, 2 containers)
   - `reitti` (postgis + redis + rabbitmq + photon + tile-cache + app, 6 containers)

   Each role gets the standard 4-file test scenario: `molecule.yml`, `verify.yml`, `verify_stopped.yml`, `side_effect.yml`.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:

All 10 new tests pass:

[new_molecule_test_results.log](https://cursor.com/agents/bc-3a3eb141-07af-4e81-a5cf-73c3dde62f3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_molecule_test_results.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a3eb141-07af-4e81-a5cf-73c3dde62f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a3eb141-07af-4e81-a5cf-73c3dde62f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

