### PR TITLE
feat: add Homepage labels for Arr stack

### DIFF
--- a/nas.yml
+++ b/nas.yml
@@ -479,7 +479,7 @@
     - role: promtail
       tags: [promtail]
     - role: prowlarr
-      tags: [prowlarr]
+      tags: [prowlarr, core]
     - role: pyload
       tags: [pyload]
     - role: pytivo
@@ -527,7 +527,7 @@
     - role: snipeit
       tags: [snipeit]
     - role: sonarr
-      tags: [sonarr]
+      tags: [sonarr, core]
     - role: sparkyfitness
       tags: [sparkyfitness]
     - role: speedtest-tracker

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: 7.4.7
 
   - name: geerlingguy.nfs
-    version: 2.1.1
+    version: 2.1.0
 
   - name: stefangweichinger.ansible_rclone
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ roles:
     version: 7.4.7
 
   - name: geerlingguy.nfs
-    version: 2.1.0
+    version: 2.1.1
 
   - name: stefangweichinger.ansible_rclone
 

--- a/roles/prowlarr/tasks/main.yml
+++ b/roles/prowlarr/tasks/main.yml
@@ -38,8 +38,8 @@
           homepage.group: Download Tools
           homepage.name: Prowlarr
           homepage.icon: prowlarr
-          homepage.href: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ prowlarr_port }}"
-          homepage.description: Indexer Proxy
+          homepage.href: "https://{{ prowlarr_hostname }}.{{ ansible_nas_domain }}"
+          homepage.description: Indexer proxy
 
   when: prowlarr_enabled is true
 

--- a/roles/prowlarr/tasks/main.yml
+++ b/roles/prowlarr/tasks/main.yml
@@ -35,7 +35,7 @@
           traefik.http.routers.prowlarr.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.prowlarr.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.prowlarr.loadbalancer.server.port: "9696"
-          homepage.group: Download Tools
+          homepage.group: Media
           homepage.name: Prowlarr
           homepage.icon: prowlarr
           homepage.href: "https://{{ prowlarr_hostname }}.{{ ansible_nas_domain }}"

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -37,7 +37,7 @@
           traefik.http.routers.sonarr.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.sonarr.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.sonarr.loadbalancer.server.port: "8989"
-          homepage.group: Download Tools
+          homepage.group: Media
           homepage.name: Sonarr
           homepage.icon: sonarr
           homepage.href: "https://{{ sonarr_hostname }}.{{ ansible_nas_domain }}"

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -37,6 +37,11 @@
           traefik.http.routers.sonarr.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.sonarr.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.sonarr.loadbalancer.server.port: "8989"
+          homepage.group: Download Tools
+          homepage.name: Sonarr
+          homepage.icon: sonarr
+          homepage.href: "https://{{ sonarr_hostname }}.{{ ansible_nas_domain }}"
+          homepage.description: TV show management
   when: sonarr_enabled is true
 
 - name: Stop Sonarr

--- a/roles/transmission-with-openvpn/tasks/main.yml
+++ b/roles/transmission-with-openvpn/tasks/main.yml
@@ -58,10 +58,10 @@
           traefik.http.routers.transmission_openvpn.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.transmission_openvpn.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.transmission_openvpn.loadbalancer.server.port: "9091"
-          homepage.group: Media
+          homepage.group: Download Tools
           homepage.name: Transmission
           homepage.icon: transmission
-          homepage.href: "https://{{transmission_openvpn_hostname}}.{{ ansible_nas_domain }}/transmission/web/"
+          homepage.href: "https://{{ transmission_openvpn_hostname }}.{{ ansible_nas_domain }}/transmission/web/"
           homepage.description: Torrent client
           homepage.widget.type: transmission
           homepage.widget.url: "http://{{ ansible_nas_hostname }}:{{ transmission_openvpn_webui_port }}"

--- a/roles/transmission-with-openvpn/tasks/main.yml
+++ b/roles/transmission-with-openvpn/tasks/main.yml
@@ -58,7 +58,7 @@
           traefik.http.routers.transmission_openvpn.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.transmission_openvpn.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.transmission_openvpn.loadbalancer.server.port: "9091"
-          homepage.group: Download Tools
+          homepage.group: Media
           homepage.name: Transmission
           homepage.icon: transmission
           homepage.href: "https://{{ transmission_openvpn_hostname }}.{{ ansible_nas_domain }}/transmission/web/"


### PR DESCRIPTION
## Summary
- add Homepage Docker discovery labels to Sonarr
- update Prowlarr Homepage link to use its public Traefik hostname
- group Transmission with OpenVPN under Download Tools and normalize its public URL template

## Validation
- Parsed changed Ansible task files with Python/PyYAML

Closes vanklompf/AnsibleNasConfigs#3
